### PR TITLE
feat(#20): add GitHub Action entrypoint for PR analysis

### DIFF
--- a/.github/workflows/pr_analysis.yml
+++ b/.github/workflows/pr_analysis.yml
@@ -31,11 +31,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
+      - name: Install struct-ia
         run: |
           pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
+          pip install "git+https://github.com/struct-ai/struct-ai.git@main"
 
       - name: Run struct-ia PR analysis
         run: python -m struct_ai.entrypoints.github_action.main

--- a/.github/workflows/pr_analysis.yml
+++ b/.github/workflows/pr_analysis.yml
@@ -1,0 +1,55 @@
+name: PR Analysis
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+# Minimal permissions: read code, write PR comments.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  struct-ia-review:
+    name: struct-ia — Clean Architecture Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Full history required for git diff against origin/main
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run struct-ia PR analysis
+        run: python -m struct_ai.entrypoints.github_action.main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.number }}
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Uncomment the provider you want to use instead of OpenAI:
+          # ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          # GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+          # OLLAMA_BASE_URL: ${{ secrets.OLLAMA_BASE_URL }}
+          #
+          # Set to "false" to make violations warnings-only (CI won't fail).
+          STRUCT_IA_FAIL_ON_VIOLATION: "true"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "rich",
     "loguru",
     "pyyaml",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ ruff==0.11.2
 black
 mypy
 types-PyYAML
+types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ typer
 rich
 loguru
 pyyaml
+requests

--- a/src/struct_ai/entrypoints/github_action/main.py
+++ b/src/struct_ai/entrypoints/github_action/main.py
@@ -1,0 +1,329 @@
+"""GitHub Action entrypoint for struct-ia.
+
+Analyses only the Python files changed in the current Pull Request.
+Expected to run inside a GitHub Actions workflow with the following
+environment variables:
+
+  GITHUB_TOKEN        – automatically injected by GitHub Actions
+  GITHUB_REPOSITORY   – "owner/repo", e.g. "struct-ai/struct-ai"
+  PR_NUMBER           – pull-request number (set from github.event.number)
+  GITHUB_WORKSPACE    – absolute path to the checked-out repository root
+  STRUCT_IA_FAIL_ON_VIOLATION – set to "false" to disable CI failure on
+                                violations (default: "true")
+
+Provider resolution follows the same order as the CLI:
+  .struct-ia.yaml 'provider' key > env-var auto-detection
+  (OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_API_KEY, MISTRAL_API_KEY, OLLAMA_BASE_URL)
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Sequence
+
+import requests
+from loguru import logger
+
+from struct_ai.adapters.ai.mentor_adapter_factory import build_mentor_adapter
+from struct_ai.adapters.config.yaml_config_reader import YamlConfigReader
+from struct_ai.adapters.io.pathlib_source_file_reader import PathlibSourceFileReader
+from struct_ai.adapters.parsers.python_ast_adapter import PythonAstAdapter
+from struct_ai.core.entities.analysis_result import AnalysisResult
+from struct_ai.core.entities.config import DEFAULT_CONFIG, StructIaConfig
+from struct_ai.core.exceptions.exceptions import (
+    AIMentorResponseError,
+    InvalidCodeError,
+    InvalidConfigError,
+)
+from struct_ai.core.use_cases.review_code_use_case import ReviewCodeUseCase
+
+_GITHUB_API_BASE = "https://api.github.com"
+
+# Marker embedded in every comment so we can identify ours without updating.
+# Each run posts a fresh comment (history is preserved intentionally).
+_COMMENT_HEADER = "<!-- struct-ia-pr-analysis -->"
+
+
+def main() -> None:
+    """Entry point: analyse PR-changed files and report results."""
+    workspace = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    repository = os.environ.get("GITHUB_REPOSITORY", "")
+    pr_number_raw = os.environ.get("PR_NUMBER", "")
+    fail_on_violation = (
+        os.environ.get("STRUCT_IA_FAIL_ON_VIOLATION", "true").lower() != "false"
+    )
+
+    changed_python_files = _get_changed_python_files(workspace)
+
+    if not changed_python_files:
+        message = (
+            "struct-ia: aucun fichier .py modifié dans cette PR — rien à analyser."
+        )
+        logger.info(message)
+        print(message)
+        _post_pr_comment(
+            token=github_token,
+            repository=repository,
+            pr_number=pr_number_raw,
+            body=_build_no_files_comment(),
+        )
+        sys.exit(0)
+
+    config = _load_config(workspace)
+
+    try:
+        use_case = _build_use_case(config)
+    except (EnvironmentError, ImportError) as error:
+        logger.error("Provider configuration error: {error}", error=error)
+        print(f"::error::struct-ia — erreur de configuration du provider: {error}")
+        sys.exit(1)
+
+    all_results = _run_analysis(use_case, changed_python_files, workspace)
+
+    _emit_annotations(all_results)
+
+    comment_body = _build_pr_comment(all_results, changed_python_files)
+    _post_pr_comment(
+        token=github_token,
+        repository=repository,
+        pr_number=pr_number_raw,
+        body=comment_body,
+    )
+
+    violations_count = len(all_results)
+    if violations_count > 0 and fail_on_violation:
+        logger.error(
+            "{count} violation(s) détectée(s) — CI en échec.", count=violations_count
+        )
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Git helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_changed_python_files(workspace: Path) -> list[Path]:
+    """Return the list of .py files changed in the PR via git diff.
+
+    Compares HEAD against the remote base branch (origin/main by default).
+    Falls back to listing all .py files if the diff command fails
+    (e.g. in local testing outside a real PR context).
+    """
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=ACM", "origin/main...HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=workspace,
+        )
+        raw_paths = [
+            line.strip() for line in result.stdout.splitlines() if line.strip()
+        ]
+        python_files = [
+            workspace / path
+            for path in raw_paths
+            if path.endswith(".py") and (workspace / path).is_file()
+        ]
+        logger.info(
+            "{count} fichier(s) .py modifié(s) détecté(s).", count=len(python_files)
+        )
+        return python_files
+    except subprocess.CalledProcessError as error:
+        logger.warning(
+            "git diff a échoué — fallback sur tous les .py. Erreur: {error}",
+            error=error,
+        )
+        return sorted(workspace.rglob("*.py"))
+
+
+# ---------------------------------------------------------------------------
+# Config & use-case wiring
+# ---------------------------------------------------------------------------
+
+
+def _load_config(project_root: Path) -> StructIaConfig:
+    """Load .struct-ia.yaml from project root, fall back to DEFAULT_CONFIG."""
+    reader = YamlConfigReader()
+    try:
+        config = reader.read(project_root)
+        logger.info(
+            "Configuration chargée depuis {path}", path=project_root / ".struct-ia.yaml"
+        )
+        return config
+    except InvalidConfigError as error:
+        logger.error(
+            "Fichier de configuration invalide : {detail}", detail=error.detail
+        )
+        print(f"::error::struct-ia — .struct-ia.yaml invalide: {error.detail}")
+        sys.exit(1)
+    except Exception:
+        logger.warning(
+            "Aucun .struct-ia.yaml trouvé dans {root} — règles par défaut utilisées.",
+            root=project_root,
+        )
+        return DEFAULT_CONFIG
+
+
+def _build_use_case(config: StructIaConfig) -> ReviewCodeUseCase:
+    """Wire concrete adapters into ReviewCodeUseCase."""
+    source_reader = PathlibSourceFileReader()
+    parser = PythonAstAdapter()
+    ai_mentor = build_mentor_adapter(config.provider)
+    return ReviewCodeUseCase(source_reader, parser, ai_mentor, config)
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
+
+def _run_analysis(
+    use_case: ReviewCodeUseCase,
+    python_files: Sequence[Path],
+    base_directory: Path,
+) -> list[AnalysisResult]:
+    """Run the use case on every file and collect all AnalysisResult objects."""
+    all_results: list[AnalysisResult] = []
+
+    for file_path in python_files:
+        relative_path = file_path.relative_to(base_directory)
+        try:
+            results = use_case.execute(str(file_path))
+        except InvalidCodeError as error:
+            logger.warning(
+                "Fichier ignoré (code invalide) : {path} — {log}",
+                path=file_path,
+                log=error.log,
+            )
+            continue
+        except AIMentorResponseError as error:
+            logger.error(
+                "Réponse IA malformée pour {path} : {error}",
+                path=file_path,
+                error=error,
+            )
+            continue
+        except Exception as error:  # noqa: BLE001
+            logger.error(
+                "Erreur inattendue pour {path} : {error}", path=file_path, error=error
+            )
+            continue
+
+        if results:
+            all_results.extend(results)
+            logger.info(
+                "{path} — {count} violation(s).", path=relative_path, count=len(results)
+            )
+        else:
+            logger.info("{path} — aucune violation.", path=relative_path)
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions annotations
+# ---------------------------------------------------------------------------
+
+
+def _emit_annotations(results: list[AnalysisResult]) -> None:
+    """Print GitHub Actions ::error annotations for each violation.
+
+    These appear as inline annotations in the PR 'Files changed' tab.
+    """
+    for result in results:
+        safe_message = result.mentor_feedback.concept_name.replace("\n", " ").replace(
+            "%", "%25"
+        )
+        print(
+            f"::error file={result.file_path},line={result.line_number}"
+            f",title=Clean Architecture violation::{safe_message} [{result.rule_violation.value}]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# PR comment formatting & posting
+# ---------------------------------------------------------------------------
+
+
+def _build_no_files_comment() -> str:
+    return (
+        f"{_COMMENT_HEADER}\n"
+        "## struct-ia — Analyse architecturale\n\n"
+        "> ℹ️ Aucun fichier Python modifié dans cette PR. Rien à analyser."
+    )
+
+
+def _build_pr_comment(
+    results: list[AnalysisResult], analyzed_files: Sequence[Path]
+) -> str:
+    """Build a Markdown summary comment for the PR."""
+    file_count = len(analyzed_files)
+    violation_count = len(results)
+
+    lines: list[str] = [_COMMENT_HEADER, "## struct-ia — Analyse architecturale\n"]
+
+    if violation_count == 0:
+        lines.append(
+            f"✅ **Aucune violation détectée** sur {file_count} fichier(s) analysé(s)."
+        )
+        return "\n".join(lines)
+
+    lines.append(
+        f"❌ **{violation_count} violation(s) détectée(s)** sur {file_count} fichier(s) analysé(s).\n"
+    )
+
+    for result in results:
+        suggestion = result.mentor_feedback
+        lines.append(f"---\n### `{result.file_path}` — ligne {result.line_number}")
+        lines.append(f"**Règle violée :** `{result.rule_violation.value}`")
+        lines.append(f"**Concept :** {suggestion.concept_name}\n")
+        lines.append(f"> {suggestion.educational_explanation}\n")
+        lines.append("<details><summary>Voir l'exemple de refactoring</summary>\n")
+        lines.append(f"**Avant :**\n```python\n{suggestion.code_before}\n```\n")
+        lines.append(f"**Après :**\n```python\n{suggestion.code_after}\n```")
+        if suggestion.documentation_links:
+            links_md = "\n".join(f"- {link}" for link in suggestion.documentation_links)
+            lines.append(f"\n**Ressources :**\n{links_md}")
+        lines.append("</details>\n")
+
+    return "\n".join(lines)
+
+
+def _post_pr_comment(token: str, repository: str, pr_number: str, body: str) -> None:
+    """Post a comment on the PR via the GitHub REST API.
+
+    Logs a warning and continues without raising when the token or PR number
+    is absent (e.g. during local testing).
+    """
+    if not token or not repository or not pr_number:
+        logger.warning(
+            "GITHUB_TOKEN, GITHUB_REPOSITORY ou PR_NUMBER manquant — "
+            "le commentaire de PR ne sera pas publié."
+        )
+        return
+
+    url = f"{_GITHUB_API_BASE}/repos/{repository}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        response = requests.post(url, json={"body": body}, headers=headers, timeout=15)
+        response.raise_for_status()
+        logger.info("Commentaire publié sur la PR #{pr_number}.", pr_number=pr_number)
+    except requests.RequestException as error:
+        logger.error(
+            "Échec de la publication du commentaire GitHub : {error}", error=error
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_github_action_main.py
+++ b/tests/test_github_action_main.py
@@ -1,0 +1,433 @@
+"""Tests for the GitHub Action entrypoint."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from struct_ai.core.entities.analysis_result import AnalysisResult
+from struct_ai.core.entities.rule_type import RuleType
+from struct_ai.core.entities.suggestion import Suggestion
+from struct_ai.core.exceptions.exceptions import AIMentorResponseError, InvalidCodeError
+from struct_ai.entrypoints.github_action import main as github_action_module
+
+_SUGGESTION = Suggestion(
+    concept_name="Layer Isolation",
+    educational_explanation="Domain code must never import from the adapters layer.",
+    code_before="from struct_ai.adapters.parsers import python_ast_adapter",
+    code_after="from struct_ai.core.interfaces.outputs.code_parser_port import CodeParserPort",
+    documentation_links=["https://example.com/clean-arch"],
+)
+
+_ANALYSIS_RESULT = AnalysisResult(
+    file_path="src/core/domain.py",
+    line_number=5,
+    rule_violation=RuleType.LAYER_VIOLATION,
+    mentor_feedback=_SUGGESTION,
+)
+
+_BASE_ENV = {
+    "GITHUB_TOKEN": "gh-test-token",
+    "GITHUB_REPOSITORY": "owner/repo",
+    "PR_NUMBER": "42",
+    "STRUCT_IA_FAIL_ON_VIOLATION": "true",
+}
+
+
+# ---------------------------------------------------------------------------
+# _get_changed_python_files
+# ---------------------------------------------------------------------------
+
+
+def describe_get_changed_python_files() -> None:
+    def it_returns_python_files_from_git_diff(tmp_path: Path) -> None:
+        py_file = tmp_path / "module.py"
+        py_file.write_text("x = 1\n", encoding="utf-8")
+
+        mock_result = MagicMock()
+        mock_result.stdout = "module.py\n"
+
+        with patch("subprocess.run", return_value=mock_result):
+            files = github_action_module._get_changed_python_files(tmp_path)
+
+        assert files == [py_file]
+
+    def it_ignores_non_python_files(tmp_path: Path) -> None:
+        (tmp_path / "module.py").write_text("x = 1\n", encoding="utf-8")
+
+        mock_result = MagicMock()
+        mock_result.stdout = "module.py\nREADME.md\nconfig.yaml\n"
+
+        with patch("subprocess.run", return_value=mock_result):
+            files = github_action_module._get_changed_python_files(tmp_path)
+
+        assert all(f.suffix == ".py" for f in files)
+        assert len(files) == 1
+
+    def it_falls_back_to_rglob_when_git_diff_fails(tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("", encoding="utf-8")
+        (tmp_path / "b.py").write_text("", encoding="utf-8")
+
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "git"),
+        ):
+            files = github_action_module._get_changed_python_files(tmp_path)
+
+        assert len(files) == 2
+        assert all(f.suffix == ".py" for f in files)
+
+    def it_returns_empty_list_when_no_python_files_changed(tmp_path: Path) -> None:
+        mock_result = MagicMock()
+        mock_result.stdout = "README.md\n"
+
+        with patch("subprocess.run", return_value=mock_result):
+            files = github_action_module._get_changed_python_files(tmp_path)
+
+        assert files == []
+
+
+# ---------------------------------------------------------------------------
+# _build_pr_comment
+# ---------------------------------------------------------------------------
+
+
+def describe_build_pr_comment() -> None:
+    def it_contains_success_message_when_no_violations(tmp_path: Path) -> None:
+        comment = github_action_module._build_pr_comment([], [tmp_path / "a.py"])
+        assert "Aucune violation" in comment
+        assert "✅" in comment
+
+    def it_contains_violation_count_when_violations_found(tmp_path: Path) -> None:
+        py_file = tmp_path / "core/domain.py"
+        comment = github_action_module._build_pr_comment([_ANALYSIS_RESULT], [py_file])
+        assert "1 violation(s)" in comment
+        assert "❌" in comment
+
+    def it_contains_file_path_and_line_number(tmp_path: Path) -> None:
+        py_file = tmp_path / "core/domain.py"
+        comment = github_action_module._build_pr_comment([_ANALYSIS_RESULT], [py_file])
+        assert "src/core/domain.py" in comment
+        assert "ligne 5" in comment
+
+    def it_contains_concept_name(tmp_path: Path) -> None:
+        py_file = tmp_path / "core/domain.py"
+        comment = github_action_module._build_pr_comment([_ANALYSIS_RESULT], [py_file])
+        assert _SUGGESTION.concept_name in comment
+
+    def it_contains_documentation_links_when_present(tmp_path: Path) -> None:
+        py_file = tmp_path / "core/domain.py"
+        comment = github_action_module._build_pr_comment([_ANALYSIS_RESULT], [py_file])
+        assert "https://example.com/clean-arch" in comment
+
+    def it_contains_html_marker(tmp_path: Path) -> None:
+        comment = github_action_module._build_pr_comment([], [])
+        assert github_action_module._COMMENT_HEADER in comment
+
+
+def describe_build_no_files_comment() -> None:
+    def it_contains_no_files_message() -> None:
+        comment = github_action_module._build_no_files_comment()
+        assert "Aucun fichier Python" in comment
+        assert github_action_module._COMMENT_HEADER in comment
+
+
+# ---------------------------------------------------------------------------
+# _emit_annotations
+# ---------------------------------------------------------------------------
+
+
+def describe_emit_annotations() -> None:
+    def it_prints_github_error_annotation(capsys: pytest.CaptureFixture[str]) -> None:
+        github_action_module._emit_annotations([_ANALYSIS_RESULT])
+        captured = capsys.readouterr()
+        assert "::error file=" in captured.out
+        assert "src/core/domain.py" in captured.out
+        assert "line=5" in captured.out
+
+    def it_prints_nothing_when_no_results(capsys: pytest.CaptureFixture[str]) -> None:
+        github_action_module._emit_annotations([])
+        captured = capsys.readouterr()
+        assert captured.out == ""
+
+
+# ---------------------------------------------------------------------------
+# _post_pr_comment
+# ---------------------------------------------------------------------------
+
+
+def describe_post_pr_comment() -> None:
+    def it_skips_posting_when_token_is_missing() -> None:
+        with patch("requests.post") as mock_post:
+            github_action_module._post_pr_comment(
+                token="",
+                repository="owner/repo",
+                pr_number="42",
+                body="hello",
+            )
+        mock_post.assert_not_called()
+
+    def it_skips_posting_when_repository_is_missing() -> None:
+        with patch("requests.post") as mock_post:
+            github_action_module._post_pr_comment(
+                token="gh-token",
+                repository="",
+                pr_number="42",
+                body="hello",
+            )
+        mock_post.assert_not_called()
+
+    def it_skips_posting_when_pr_number_is_missing() -> None:
+        with patch("requests.post") as mock_post:
+            github_action_module._post_pr_comment(
+                token="gh-token",
+                repository="owner/repo",
+                pr_number="",
+                body="hello",
+            )
+        mock_post.assert_not_called()
+
+    def it_posts_comment_to_correct_github_url() -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            github_action_module._post_pr_comment(
+                token="gh-token",
+                repository="owner/repo",
+                pr_number="42",
+                body="hello",
+            )
+
+        mock_post.assert_called_once()
+        called_url = mock_post.call_args[0][0]
+        assert "owner/repo" in called_url
+        assert "42" in called_url
+        assert called_url.startswith("https://api.github.com")
+
+    def it_uses_bearer_authorization_header() -> None:
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+
+        with patch("requests.post", return_value=mock_response) as mock_post:
+            github_action_module._post_pr_comment(
+                token="my-secret-token",
+                repository="owner/repo",
+                pr_number="1",
+                body="hello",
+            )
+
+        headers = mock_post.call_args[1]["headers"]
+        assert headers["Authorization"] == "Bearer my-secret-token"
+
+
+# ---------------------------------------------------------------------------
+# _run_analysis
+# ---------------------------------------------------------------------------
+
+
+def describe_run_analysis() -> None:
+    def it_returns_empty_list_when_no_violations(tmp_path: Path) -> None:
+        py_file = tmp_path / "clean.py"
+        py_file.write_text("x = 1\n", encoding="utf-8")
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.return_value = ()
+
+        results = github_action_module._run_analysis(mock_use_case, [py_file], tmp_path)
+        assert results == []
+
+    def it_collects_violations_from_multiple_files(tmp_path: Path) -> None:
+        file_a = tmp_path / "a.py"
+        file_b = tmp_path / "b.py"
+        file_a.write_text("x = 1\n", encoding="utf-8")
+        file_b.write_text("y = 2\n", encoding="utf-8")
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = [(_ANALYSIS_RESULT,), (_ANALYSIS_RESULT,)]
+
+        results = github_action_module._run_analysis(
+            mock_use_case, [file_a, file_b], tmp_path
+        )
+        assert len(results) == 2
+
+    def it_skips_file_on_invalid_code_error(tmp_path: Path) -> None:
+        file_a = tmp_path / "bad.py"
+        file_b = tmp_path / "good.py"
+        file_a.write_text("???", encoding="utf-8")
+        file_b.write_text("x = 1\n", encoding="utf-8")
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = [InvalidCodeError("syntax error"), ()]
+
+        results = github_action_module._run_analysis(
+            mock_use_case, [file_a, file_b], tmp_path
+        )
+        assert results == []
+        assert mock_use_case.execute.call_count == 2
+
+    def it_skips_file_on_ai_mentor_response_error(tmp_path: Path) -> None:
+        py_file = tmp_path / "problematic.py"
+        py_file.write_text("x = 1\n", encoding="utf-8")
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.side_effect = [
+            AIMentorResponseError("bad JSON", raw_response="{}")
+        ]
+
+        results = github_action_module._run_analysis(mock_use_case, [py_file], tmp_path)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# main() integration
+# ---------------------------------------------------------------------------
+
+
+def describe_main() -> None:
+    def it_exits_0_when_no_python_files_changed(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        for key, value in _BASE_ENV.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+
+        mock_result = MagicMock()
+        mock_result.stdout = "README.md\n"
+
+        with (
+            patch("subprocess.run", return_value=mock_result),
+            patch(
+                "requests.post", return_value=MagicMock(raise_for_status=MagicMock())
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            github_action_module.main()
+
+        assert exc_info.value.code == 0
+
+    def it_exits_0_when_no_violations_found(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        for key, value in _BASE_ENV.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("STRUCT_IA_FAIL_ON_VIOLATION", "true")
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+
+        py_file = tmp_path / "clean.py"
+        py_file.write_text("x = 1\n", encoding="utf-8")
+
+        mock_git_result = MagicMock()
+        mock_git_result.stdout = "clean.py\n"
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.return_value = ()
+
+        with (
+            patch("subprocess.run", return_value=mock_git_result),
+            patch(
+                "struct_ai.entrypoints.github_action.main._build_use_case",
+                return_value=mock_use_case,
+            ),
+            patch(
+                "requests.post", return_value=MagicMock(raise_for_status=MagicMock())
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            github_action_module.main()
+
+        assert exc_info.value.code == 0
+
+    def it_exits_1_when_violations_found_and_fail_on_violation_is_true(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        for key, value in _BASE_ENV.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("STRUCT_IA_FAIL_ON_VIOLATION", "true")
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+
+        py_file = tmp_path / "violating.py"
+        py_file.write_text("from adapters import foo\n", encoding="utf-8")
+
+        mock_git_result = MagicMock()
+        mock_git_result.stdout = "violating.py\n"
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.return_value = (_ANALYSIS_RESULT,)
+
+        with (
+            patch("subprocess.run", return_value=mock_git_result),
+            patch(
+                "struct_ai.entrypoints.github_action.main._build_use_case",
+                return_value=mock_use_case,
+            ),
+            patch(
+                "requests.post", return_value=MagicMock(raise_for_status=MagicMock())
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            github_action_module.main()
+
+        assert exc_info.value.code == 1
+
+    def it_exits_0_when_violations_found_but_fail_on_violation_is_false(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        for key, value in _BASE_ENV.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("STRUCT_IA_FAIL_ON_VIOLATION", "false")
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+
+        py_file = tmp_path / "violating.py"
+        py_file.write_text("from adapters import foo\n", encoding="utf-8")
+
+        mock_git_result = MagicMock()
+        mock_git_result.stdout = "violating.py\n"
+
+        mock_use_case = MagicMock()
+        mock_use_case.execute.return_value = (_ANALYSIS_RESULT,)
+
+        with (
+            patch("subprocess.run", return_value=mock_git_result),
+            patch(
+                "struct_ai.entrypoints.github_action.main._build_use_case",
+                return_value=mock_use_case,
+            ),
+            patch(
+                "requests.post", return_value=MagicMock(raise_for_status=MagicMock())
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            github_action_module.main()
+
+        assert exc_info.value.code == 0
+
+    def it_exits_1_when_provider_not_configured(
+        monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        for key, value in _BASE_ENV.items():
+            monkeypatch.setenv(key, value)
+        monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+        for env_var in (
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "GOOGLE_API_KEY",
+            "MISTRAL_API_KEY",
+            "OLLAMA_BASE_URL",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+
+        py_file = tmp_path / "module.py"
+        py_file.write_text("x = 1\n", encoding="utf-8")
+
+        mock_git_result = MagicMock()
+        mock_git_result.stdout = "module.py\n"
+
+        with (
+            patch("subprocess.run", return_value=mock_git_result),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            github_action_module.main()
+
+        assert exc_info.value.code == 1


### PR DESCRIPTION
## PR Type
Feature

## Summary
Adds a GitHub Action that automatically analyses only the Python files modified in a Pull Request, detects Clean Architecture violations, and reports results directly on the PR.

## Description
Closes #20.

Two new components added without touching existing code (CLI, core, adapters unchanged).

**Entrypoint `src/struct_ai/entrypoints/github_action/main.py`**
- Retrieves changed `.py` files via `git diff --name-only origin/main...HEAD`
- Loads `.struct-ia.yaml` from the repo root (fallback to `DEFAULT_CONFIG`)
- Runs `ReviewCodeUseCase` on each changed file (same pipeline as the CLI)
- Emits `::error` GitHub Actions annotations → visible inline in the *Files changed* tab
- Posts a Markdown summary comment on the PR via the GitHub REST API (`requests` + `GITHUB_TOKEN`)
- `STRUCT_IA_FAIL_ON_VIOLATION=false` to switch to warn-only mode

**Workflow `.github/workflows/pr_analysis.yml`**
- Trigger: `pull_request` (opened / synchronize / reopened) targeting `main`
- Minimal permissions: `contents:read` + `pull-requests:write`
- Default provider: `OPENAI_API_KEY` — other providers commented out for easy swap

## What's Changed
- [x] `src/struct_ai/entrypoints/github_action/main.py` — new GitHub Action entrypoint
- [x] `.github/workflows/pr_analysis.yml` — new CI workflow
- [x] `requirements.txt` — added `requests`
- [x] `requirements-dev.txt` — added `types-requests` (mypy stubs)
- [x] `tests/test_github_action_main.py` — 27 tests (git diff parsing, comment formatting, annotations, API call, `main()` integration)

## Screen
N/A — GitHub Actions workflow

## Will
- Trigger on every PR opened or updated against `main`
- Requires `OPENAI_API_KEY` (or another provider) set in repository secrets
- Publish inline annotations + a Markdown summary comment on the PR
---